### PR TITLE
utf8stringでsliceを使っている箇所のバグを修正した

### DIFF
--- a/event.go
+++ b/event.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"discord-notion-expander/utils"
-	"log"
-
 	"github.com/bwmarrin/discordgo"
 	"github.com/kjk/notionapi"
+	"github.com/thoas/go-funk"
 	"golang.org/x/exp/utf8string"
+	"log"
 )
 
 type MessageEventHandler struct {
@@ -36,7 +36,8 @@ func (messageEventHandler *MessageEventHandler) onMessage(session *discordgo.Ses
 	rootPage := page.Root()
 	title := rootPage.Title
 	pageText := utils.GetNotionTextFromBlocks(rootPage.Content)
-	pageTextWithMaxLength := utf8string.NewString(pageText).Slice(0, 250)
+	pageTextUtf8String := utf8string.NewString(pageText)
+	pageTextWithMaxLength := pageTextUtf8String.Slice(0, funk.MaxInt([]int{250, pageTextUtf8String.RuneCount()}).(int))
 	if _, err := session.ChannelMessageSendEmbed(message.ChannelID, &discordgo.MessageEmbed{
 		URL:         page.NotionURL(),
 		Title:       title,

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/joho/godotenv v1.3.0
 	github.com/kjk/notionapi v0.0.0-20210416062710-878a08dbe82d
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/thoas/go-funk v0.8.0 // indirect
 	golang.org/x/exp v0.0.0-20210503015746-b3083d562e1d
 	gotest.tools v2.2.0+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoH
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/thoas/go-funk v0.8.0 h1:JP9tKSvnpFVclYgDM0Is7FD9M4fhPvqA0s0BsXmzSRQ=
+github.com/thoas/go-funk v0.8.0/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=


### PR DESCRIPTION
.Slice(0, 250)みたいなことをしたとき、250文字に満たない文字だった時にコケて死ぬので修正した。